### PR TITLE
Enable Java LSP with nvim-jdtls

### DIFF
--- a/lua/plugins/jdtls.lua
+++ b/lua/plugins/jdtls.lua
@@ -1,0 +1,16 @@
+return {
+  {
+    "mfussenegger/nvim-jdtls",
+    ft = { "java" },
+    config = function()
+      local jdtls = require("jdtls")
+      local capabilities = require("cmp_nvim_lsp").default_capabilities()
+      local root_markers = { "gradlew", ".git", "mvnw" }
+      local root_dir = vim.fs.dirname(vim.fs.find(root_markers, { upward = true })[1])
+      local jdtls_bin = vim.fn.exepath("jdtls")
+      if root_dir and jdtls_bin ~= "" then
+        jdtls.start_or_attach({ cmd = { jdtls_bin }, root_dir = root_dir, capabilities = capabilities })
+      end
+    end,
+  },
+}

--- a/lua/plugins/lsp-config.lua
+++ b/lua/plugins/lsp-config.lua
@@ -23,7 +23,6 @@ return {
       lspconfig.clangd.setup({ capabilities = capabilities })
       lspconfig.pyright.setup({ capabilities = capabilities })
       lspconfig.rust_analyzer.setup({ capabilities = capabilities })
-      lspconfig.jdtls.setup({ capabilities = capabilities })
 
       vim.keymap.set("n", "K", vim.lsp.buf.hover, { desc = "LSP hover information" })
       vim.keymap.set("n", "gd", vim.lsp.buf.definition, { desc = "LSP got to definition" })


### PR DESCRIPTION
## Summary
- add `nvim-jdtls` plugin for Java support
- remove default jdtls config from `lsp-config.lua`

## Testing
- `nvim` **not available** in container
- `lua` **not available** in container

------
https://chatgpt.com/codex/tasks/task_e_68531c90abb8832a98b0c5e36ce30e4b