### PR TITLE
Expand lazy.nvim install path before runtimepath insertion

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -1,5 +1,5 @@
 -- Bootstrap lazy.nvim
-local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+local lazypath = vim.fn.expand(vim.fn.stdpath("data") .. "/lazy/lazy.nvim")
 if not (vim.uv or vim.loop).fs_stat(lazypath) then
   local lazyrepo = "https://github.com/folke/lazy.nvim.git"
   local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })


### PR DESCRIPTION
### Motivation
- Ensure the `lazy.nvim` install path has any `~` expanded so the file existence check and runtimepath insertion reliably locate the plugin directory.
- Fix situations where `vim.fn.stdpath("data") .. "/lazy/lazy.nvim"` can contain an unexpanded home and cause modules (e.g. `nvim-treesitter.configs`) to not be found.

### Description
- Replace the raw concatenation with `vim.fn.expand(vim.fn.stdpath("data") .. "/lazy/lazy.nvim")` when computing the `lazypath` variable.
- The expanded `lazypath` continues to be used for the `fs_stat` check and for `vim.opt.rtp:prepend`.

### Testing
- No automated tests were run for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f8217a88832abde3745663c9c746)