### PR TITLE
Ensure nvim-treesitter runtimepath and expand lazy.nvim install path

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -1,5 +1,5 @@
 -- Bootstrap lazy.nvim
-local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+local lazypath = vim.fn.expand(vim.fn.stdpath("data") .. "/lazy/lazy.nvim")
 if not (vim.uv or vim.loop).fs_stat(lazypath) then
   local lazyrepo = "https://github.com/folke/lazy.nvim.git"
   local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -4,6 +4,10 @@ return {
       require("nvim-treesitter.install").update({ with_sync = true })()
   end,
   config = function()
+    local treesitter_path = vim.fn.stdpath("data") .. "/lazy/nvim-treesitter"
+    if vim.fn.isdirectory(treesitter_path) == 1 then
+      vim.opt.rtp:prepend(treesitter_path)
+    end
     local config = require("nvim-treesitter.configs")
     config.setup({
       ensure_installed = {"lua", "c", "cpp", "python", "rust"},
@@ -13,4 +17,3 @@ return {
     })
   end
 }
-


### PR DESCRIPTION
### Motivation
- Ensure the `lazy.nvim` install path is expanded so file existence checks and runtimepath insertion reliably locate the plugin directory.
- Prevent `require("nvim-treesitter.configs")` from failing when the `nvim-treesitter` plugin exists on disk but its directory is not on the `runtimepath`.
- Prepend the `nvim-treesitter` plugin directory to `runtimepath` before configuring it so modules are resolved reliably.

### Description
- Use `vim.fn.expand(vim.fn.stdpath("data") .. "/lazy/lazy.nvim")` to compute `lazypath` in `lua/config/lazy.lua`.
- In `lua/plugins/treesitter.lua`, compute `treesitter_path = vim.fn.stdpath("data") .. "/lazy/nvim-treesitter"` and call `vim.opt.rtp:prepend(treesitter_path)` when `vim.fn.isdirectory(treesitter_path) == 1`.
- Keep the existing `require("nvim-treesitter.configs")` and `config.setup({ ... })` logic unchanged.

### Testing
- No automated tests were run for these config-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f8217a88832abde3745663c9c746)